### PR TITLE
Add support for `map`

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -20,6 +20,7 @@ pub enum Expr {
     Filter { filter_fn: Box<Expr>, data_source: Box<Expr> },
     /* Scalars */
     RegexMatch(regex::Regex, ParsePos),
+    RegexSubst(token::RegexSubst),
     UnresolvedIdentifier(Identifier),
     FunCall { function: Box<Expr>, arguments: Vec<Expr> },
     ReadVar(runtime::StreamVar),
@@ -32,6 +33,7 @@ impl Expr {
             Self::Filter { filter_fn, data_source } =>
                 vec![filter_fn, data_source],
             Self::RegexMatch(..) => Vec::new(),
+            Self::RegexSubst(..) => Vec::new(),
             Self::Stdin => Vec::new(),
             Self::UnresolvedIdentifier(_) => Vec::new(),
             Self::FunCall { function, arguments } => {
@@ -102,6 +104,7 @@ fn trivial_expr(token: Token) -> Expr {
     match token.kind {
         Kind::Identifier(idn) => Expr::UnresolvedIdentifier(idn),
         Kind::RegexMatch(rm) => Expr::RegexMatch(rm, pos),
+        Kind::RegexSubst(subst) => Expr::RegexSubst(subst),
     }
 }
 
@@ -246,6 +249,9 @@ impl Display for Expr {
             },
             Expr::RegexMatch(re, _) => {
                 write!(f, "m/{}/", re.as_str())
+            },
+            Expr::RegexSubst(subst) => {
+                write!(f, "s/{}/{}/", subst.search.as_str(), subst.replace)
             },
             Expr::UnresolvedIdentifier(identifier) => {
                 write!(f, "?:{}:?", identifier.name)

--- a/src/parse/token.rs
+++ b/src/parse/token.rs
@@ -4,32 +4,10 @@ use regex::Regex;
 
 use crate::error::Error;
 
-#[derive(Debug)]
-pub struct Identifier {
-    pub name:     String,
-    pub position: ParsePos
-}
-
-impl Identifier {
-    fn token(m: &regex::Match) -> Token {
-        let pos = ParsePos::from(m);
-        let idn =
-            Identifier {
-                name:     m.as_str().into(),
-                position: pos,
-            };
-        Token { position: pos, kind: Kind::Identifier(idn) }
-    }
-
-    /// Take ownership of an identifier behind a ref mut,
-    /// leaving the ref pointed Identifier in a Rust-valid but
-    /// semantically invalid state.
-    pub fn take(&mut self) -> Self {
-        // Note: the docs tell us that String::new() does not lead to an allocation
-        let name = std::mem::replace(&mut self.name, String::new());
-        let position = self.position;
-        Self { name, position }
-    }
+// Should we get rid of the position field and implement the Position trait?
+pub struct Token {
+    pub position: ParsePos,
+    pub kind:     Kind,
 }
 
 pub fn tokenize<'a>(s: &'a str) -> Tokenizer<'a> {
@@ -44,11 +22,6 @@ pub struct Tokenizer<'a> {
     source:   &'a str,
     curr_pos: usize,
     token_rxs:  Vec<TokenRx>,
-}
-
-pub struct Token {
-    pub position: ParsePos,
-    pub kind:     Kind,
 }
 
 pub enum Kind {
@@ -130,7 +103,7 @@ impl<'a> Tokenizer<'a> {
 
 // Note: this definition forbids using the From trait implementation
 // TODO we can turn this into a function that returns a Kind
-type BuildFn = fn(&regex::Match) -> Token;
+type BuildFn = fn(&regex::Captures) -> Token;
 
 struct TokenRx {
     regex:    Regex,
@@ -148,29 +121,58 @@ impl From<&TRDef> for TokenRx {
     }
 }
 
-fn regex_match(m: &regex::Match) -> Token {
-    // FIXME we need to get a regex::Captures instead as argument
-    let regex_substr = &m.as_str()[2..(m.len()-1)];
+const TOKEN_RXS: [TRDef; 2] = [
+    // WARNING the ordering matters here
+    ("m/((?:[^/]|\\/)*)/",     regex_match),
+    ("[a-zA-Z][0-9a-zA-Z]*", Identifier::token),
+];
+
+fn regex_match(rec: &regex::Captures) -> Token {
+    let m = rec.get(1).unwrap();
+    let regex_substr = m.as_str();
     // FIXME need to return a proper error here
+    // What are the cases when this can fail though? Unmatched parentheses maybe?
     let re_match = Regex::new(regex_substr).unwrap();
 
-    let pos = ParsePos::from(m);
+    let pos = ParsePos::from_captures(rec);
     Token { position: pos, kind: Kind::RegexMatch(re_match) }
 }
 
-const TOKEN_RXS: [TRDef; 2] = [
-    // WARNING the ordering matters here
-    // ("m/(?:[^/]|\\/)*/\\>", regex_match),
-    ("m/(?:[^/]|\\/)*/", regex_match),
-    ("[a-zA-Z][0-9a-zA-Z]*", Identifier::token),
-];
+#[derive(Debug)]
+pub struct Identifier {
+    pub name:     String,
+    pub position: ParsePos
+}
+
+impl Identifier {
+    fn token(rec: &regex::Captures) -> Token {
+        let m = rec.get(0).unwrap();
+        let pos = ParsePos::from_match(&m);
+        let idn =
+            Identifier {
+                name:     m.as_str().into(),
+                position: pos,
+            };
+        Token { position: pos, kind: Kind::Identifier(idn) }
+    }
+
+    /// Take ownership of an identifier behind a ref mut,
+    /// leaving the ref pointed Identifier in a Rust-valid but
+    /// semantically invalid state.
+    pub fn take(&mut self) -> Self {
+        // Note: the docs tell us that String::new() does not lead to an allocation
+        let name = std::mem::replace(&mut self.name, String::new());
+        let position = self.position;
+        Self { name, position }
+    }
+}
 
 impl TokenRx {
     fn try_at(&self, source: &str, start: usize) -> Option<Token> {
         self.regex
-            .find_at(source, start)
-            .filter(|m| m.start() == start)
-            .map(|m| (self.build_fn)(&m))
+            .captures_at(source, start)
+            .filter(|rec| rec.get(0).unwrap().start() == start)
+            .map(|rec| (self.build_fn)(&rec))
     }
 }
 
@@ -185,11 +187,17 @@ impl ParsePos {
         ParsePos { start: pos, len: 1 }
     }
 
-    fn from(m: &regex::Match) -> Self {
+    fn from_match(m: &regex::Match) -> Self {
         ParsePos {
             start: m.start(),
             len:   m.as_str().len()
         }
+    }
+
+    fn from_captures(rec: &regex::Captures) -> Self {
+        // Note: the documentation for Captures guarantees that
+        // get(0) will never return None
+        Self::from_match(&rec.get(0).unwrap())
     }
 
     pub fn right_after(&self) -> ParsePos {

--- a/src/runtime/scalar.rs
+++ b/src/runtime/scalar.rs
@@ -9,6 +9,7 @@ pub trait ExecScalar {
     fn eval(&mut self) -> Result<RtVal, Error>;
 }
 
+#[allow(private_interfaces)]
 pub enum ScalarNode {
     RegexMatch(RegexMatch),
     RegexSubst(RegexSubst),
@@ -44,7 +45,7 @@ pub fn scalar_from(expr: Expr) -> ScalarNode {
 
 fn scalar_fun_call(function: Expr, mut arguments: Vec<Expr>) -> ScalarNode {
     match function {
-        Expr::RegexMatch(regex, pos) => {
+        Expr::RegexMatch(regex, _pos) => {
             assert_eq!(arguments.len(), 1);
             let single_arg = arguments.pop().unwrap();
             RegexMatch::new_node(regex, single_arg)

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -13,6 +13,7 @@ trait ExecStream: Iterator<Item=Result<RtVal, Error>> { }
 // Any type that has the iterator we want is considered an ExecStream
 impl<T: Iterator<Item=Result<RtVal, Error>>> ExecStream for T { }
 
+#[allow(private_interfaces)]
 pub(super) enum StreamNode {
     Stdin(StdinState),
     Filter(StreamFilter),

--- a/test/map.001.sh
+++ b/test/map.001.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+res=`echo "abc" | $PUMP 'map s/b/d/ stdin'`
+assert_eq "$res" "adc"

--- a/test/map.002.sh
+++ b/test/map.002.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+res=`echo -e "abc\nbac" | $PUMP 'map s/b/d/ stdin'`
+expected=`echo -e "adc\ndac"`
+assert_eq "$res" "$expected"

--- a/test/map.003.sh
+++ b/test/map.003.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+res=`echo -e "abc\nbac" | $PUMP 'map s/[ab]/d/ stdin'`
+expected=`echo -e "dbc\ndac"`
+assert_eq "$res" "$expected"

--- a/test/map.004.sh
+++ b/test/map.004.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+res=`echo -e "abc\nbac" | $PUMP 'map s/ab/d/ stdin'`
+expected=`echo -e "dc\nbac"`
+assert_eq "$res" "$expected"

--- a/test/map.005.sh
+++ b/test/map.005.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+res=`echo -e "abc\nbac" | $PUMP 'map s/a(b)/d\1/ stdin'`
+expected=`echo -e "dbc\nbac"`
+assert_eq "$res" "$expected"

--- a/test/map.006.sh
+++ b/test/map.006.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+res=`echo -e "abc\nbac" | $PUMP 'map s/a(b)/\1d\1/ stdin'`
+expected=`echo -e "bdbc\nbac"`
+assert_eq "$res" "$expected"

--- a/test/run.sh
+++ b/test/run.sh
@@ -26,5 +26,13 @@ invalid_program () {
 }
 export -f invalid_program
 
+assert_eq () {
+    left="$1"
+    right="$2"
+    echo "$left"
+    [ "$left" == "$right" ]
+}
+export -f invalid_program
+
 # TODO remove the second argument completely
 bash "$test_script" "$PUMP"

--- a/test/run.sh
+++ b/test/run.sh
@@ -32,7 +32,7 @@ assert_eq () {
     echo "$left"
     [ "$left" == "$right" ]
 }
-export -f invalid_program
+export -f assert_eq
 
 # TODO remove the second argument completely
 bash "$test_script" "$PUMP"


### PR DESCRIPTION
Add support for a simple `map` implementation. With the string-only status of the project, it comes with a companion "regex substitution" operator for testing.