### PR TITLE
Refactor builtin operators and functions into a new `Builtin` enum

### DIFF
--- a/src/compile.rs
+++ b/src/compile.rs
@@ -3,7 +3,7 @@ mod types;
 
 use crate::Error;
 
-pub use parse::{ParsePos, Identifier, Expr, RegexSubst, FunCall};
+pub use parse::{ParsePos, Identifier, Expr, RegexSubst, FunCall, Builtin};
 
 pub fn compile(pgm: &str) -> Result<Expr, Error> {
     eprintln!("Program: {}", pgm);

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -9,7 +9,7 @@ pub fn compile(pgm: &str) -> Result<Expr, Error> {
     eprintln!("Program: {}", pgm);
     let mut expr_tree = parse::parse(&pgm)?;
     eprintln!("Parsed program: {}", expr_tree.pretty_print());
-    types::typecheck(&mut expr_tree)?;
+    types::typecheck_program(&mut expr_tree)?;
     Ok(expr_tree)
 }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -3,7 +3,7 @@ mod types;
 
 use crate::Error;
 
-pub use parse::{ParsePos, Identifier, Expr, RegexSubst};
+pub use parse::{ParsePos, Identifier, Expr, RegexSubst, FunCall};
 
 pub fn compile(pgm: &str) -> Result<Expr, Error> {
     eprintln!("Program: {}", pgm);

--- a/src/compile/types.rs
+++ b/src/compile/types.rs
@@ -56,8 +56,32 @@ impl Typecheck for Expr {
 
 impl Typecheck for FunCall {
     fn typecheck(&mut self) -> Result<Type, Error> {
-        match self.function.typecheck()? {
+        let fn_type =
+            match self.function.as_mut() {
+                // TODO we would need to introduce full-fledged type equations here
+                Expr::Builtin(Builtin::Filter, _pos) =>
+                    typecheck_filter(&mut self.arguments)?,
+                Expr::Builtin(Builtin::Map, _pos) =>
+                    typecheck_map(&mut self.arguments)?,
+                _ => self.function.typecheck()?,
+            };
+
+        eprintln!("FunCall::typecheck: standard function call typechecking starts now");
+        match fn_type {
             Type::Function { parameters, return_type } => {
+                let n_args = self.arguments.len();
+                let n_params = parameters.len();
+
+                // Start by checking the number of arguments provided to the function
+                assert_ne!(n_params, 0);
+                if n_args < n_params {
+                    return Err(Error::NotEnoughArguments(self.arguments.last().unwrap().position().right_after()));
+                }
+                else if n_args > n_params {
+                    return Err(Error::TooManyArguments(self.arguments[n_params].position()));
+                }
+
+                // Check the types of the arguments
                 for (param_type, arg)
                 in parameters.into_iter()
                     .zip(self.arguments.iter_mut())
@@ -91,87 +115,122 @@ impl Typecheck for Builtin {
                 Ok(Type::function(vec![Type::String], Type::String)),
 
 
-            Builtin::Filter { filter_fn, data_source } => {
-                let source_type = data_source.typecheck()?;
-                let source_items: &Type =
-                    match &source_type {
-                        Type::Stream(item_type) => item_type,
-                        _ => return Err(Error::WrongArgType {
-                            expected: "any stream type".into(),
-                            found:    source_type.to_string(),
-                            err_pos:  data_source.position()
-                        }),
-                    };
-
-                // The filter function must go from the data source's item type to boolean
-                let fn_type = filter_fn.typecheck()?;
-                let expected_fn_type = Type::function(vec![source_items.clone()], Type::Bool);
-                if fn_type != expected_fn_type {
-                    return Err(Error::WrongArgType {
-                        expected: expected_fn_type.to_string(),
-                        found:    fn_type.to_string(),
-                        err_pos:  filter_fn.position()
-                    });
-                }
-
-                Ok(source_type)
-            },
-
-            Builtin::Map { map_fn, data_source } => {
-                let source_type = data_source.typecheck()?;
-                let source_items: &Type =
-                    match &source_type {
-                        Type::Stream(item_type) => item_type,
-                        _ => return Err(Error::WrongArgType {
-                            expected: "any stream type".into(),
-                            found:    source_type.to_string(),
-                            err_pos:  data_source.position()
-                        }),
-                    };
-
-                // The mapping function must take the data source's item type as argument
-                let fn_type = map_fn.typecheck()?;
-                let fn_type_str = fn_type.to_string();  // used to beat the borrow checker
-                // TODO should we remember this mapped-to type in the Map node?
-                let mapped_to =
-                    match fn_type {
-                        Type::Function { parameters, return_type } => {
-                            if parameters.len() == 1 {
-                                let single_param = parameters.first().unwrap();
-                                if single_param == source_items {
-                                    // Typecheck ok
-                                    // Give back the function's return type so we can build the final type out of it
-                                    return_type
-                                }
-                                else {
-                                    return Err(Error::WrongArgType {
-                                        expected: format!("fn ({}) -> anything", source_items.to_string()),
-                                        found:    single_param.to_string(),
-                                        err_pos:  map_fn.position()
-                                    });
-                                }
-                            }
-                            else {
-                                return Err(Error::WrongArgType {
-                                    expected: "a function of a single argument".into(),
-                                    found:    fn_type_str,
-                                    err_pos:  map_fn.position()
-                                });
-                            }
-                        }
-                        _ => {
-                            return Err(Error::WrongArgType {
-                                expected: "any function type".into(),
-                                found:    fn_type_str,
-                                err_pos:  map_fn.position()
-                            });
-                        }
-                    };
-
-                Ok(Type::Stream(mapped_to))
-            },
+            Builtin::Filter | Builtin::Map =>
+                todo!("We don't support full type equations yet"),
         }
     }
+}
+
+fn mut_pair<T>(data: &mut [T]) -> Option<(&mut T, &mut T)> {
+    if data.len() != 2 {
+        return None;
+    }
+
+    let mut iter = data.into_iter();
+    let first = iter.next().unwrap();
+    let second = iter.next().unwrap();
+    Some((first, second))
+}
+
+fn typecheck_filter(arguments: &mut [Expr]) -> Result<Type, Error> {
+    let (filter_fn, data_source) =
+        match mut_pair(arguments) {
+            Some(pair) => pair,
+            None => {
+                // Ugly hack: return a pointless function of 2 arguments that
+                // will fail in the calling FunCall typechecking
+                return Ok(Type::function(vec![Type::Bool, Type::Bool], Type::Bool));
+            }
+        };
+
+    let source_type = data_source.typecheck()?;
+    let source_items: &Type =
+        match &source_type {
+            Type::Stream(item_type) => item_type,
+            _ => return Err(Error::WrongArgType {
+                expected: "any stream type".into(),
+                found:    source_type.to_string(),
+                err_pos:  data_source.position()
+            }),
+        };
+
+    // The filter function must go from the data source's item type to boolean
+    let fn_type = filter_fn.typecheck()?;
+    let expected_fn_type = Type::function(vec![source_items.clone()], Type::Bool);
+    if fn_type != expected_fn_type {
+        return Err(Error::WrongArgType {
+            expected: expected_fn_type.to_string(),
+            found:    fn_type.to_string(),
+            err_pos:  filter_fn.position()
+        });
+    }
+
+    let return_type = Type::function(vec![expected_fn_type, source_type.clone()], source_type);
+    Ok(return_type)
+}
+
+fn typecheck_map(arguments: &mut [Expr]) -> Result<Type, Error> {
+    let (map_fn, data_source) =
+        match mut_pair(arguments) {
+            Some(pair) => pair,
+            None => {
+                // Ugly hack: return a pointless function of 2 arguments that
+                // will fail in the calling FunCall typechecking
+                return Ok(Type::function(vec![Type::Bool, Type::Bool], Type::Bool));
+            }
+        };
+
+    let source_type = data_source.typecheck()?;
+    let source_items: &Type =
+        match &source_type {
+            Type::Stream(item_type) => item_type,
+            _ => return Err(Error::WrongArgType {
+                expected: "any stream type".into(),
+                found:    source_type.to_string(),
+                err_pos:  data_source.position()
+            }),
+        };
+
+    // The mapping function must take the data source's item type as argument
+    let fn_type = map_fn.typecheck()?;
+    // TODO should we remember this mapped-to type in the Map node?
+    let mapped_to =
+        match &fn_type {
+            Type::Function { parameters, return_type } => {
+                if parameters.len() == 1 {
+                    let single_param = parameters.first().unwrap();
+                    if single_param == source_items {
+                        // Typecheck ok
+                        // Give back the function's return type so we can build the final type out of it
+                        return_type.clone()
+                    }
+                    else {
+                        return Err(Error::WrongArgType {
+                            expected: format!("fn ({}) -> anything", source_items.to_string()),
+                            found:    single_param.to_string(),
+                            err_pos:  map_fn.position()
+                        });
+                    }
+                }
+                else {
+                    return Err(Error::WrongArgType {
+                        expected: "a function of a single argument".into(),
+                        found:    fn_type.to_string(),
+                        err_pos:  map_fn.position()
+                    });
+                }
+            }
+            _ => {
+                return Err(Error::WrongArgType {
+                    expected: "any function type".into(),
+                    found:    fn_type.to_string(),
+                    err_pos:  map_fn.position()
+                });
+            }
+        };
+
+    let return_type = Type::function(vec![fn_type, source_type], Type::Stream(mapped_to));
+    Ok(return_type)
 }
 
 /* Pretty printing */

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,6 +12,7 @@ pub enum Error {
     UnrecognizedToken(ParsePos),
     NotAFunction(ParsePos),
     WrongArgType { expected: String, found: String, err_pos: ParsePos },
+    NonFormattable(String),
 }
 
 impl Error {
@@ -38,6 +39,7 @@ impl Error {
             Error::UnrecognizedToken(err_pos) => Some(*err_pos),
             Error::NotAFunction(err_pos) => Some(*err_pos),
             Error::WrongArgType { err_pos, .. } => Some(*err_pos),
+            Error::NonFormattable(_) => None,
         }
     }
 }
@@ -68,6 +70,8 @@ impl Display for Error {
                 write!(f, "Not a function"),
             Error::WrongArgType { expected, found, .. } =>
                 write!(f, "Wrong argument type in function call: expected {}, found {}", expected, found),
+            Error::NonFormattable(type_str) =>
+                write!(f, "Top-level program type cannot be formatted: {}", type_str),
         }
     }
 }

--- a/src/runtime/scalar.rs
+++ b/src/runtime/scalar.rs
@@ -31,8 +31,8 @@ impl ExecScalar for ScalarNode {
 // TODO convert into From impl
 pub fn scalar_from(expr: Expr) -> ScalarNode {
     match expr {
-        Expr::FunCall { function, arguments } =>
-            scalar_fun_call(*function, arguments),
+        Expr::FunCall(fcall) =>
+            scalar_fun_call(fcall),
 
         Expr::ReadVar(var) => ReadStreamVar::new_node(var),
 
@@ -44,16 +44,16 @@ pub fn scalar_from(expr: Expr) -> ScalarNode {
     }
 }
 
-fn scalar_fun_call(function: Expr, mut arguments: Vec<Expr>) -> ScalarNode {
-    match function {
+fn scalar_fun_call(mut fcall: compile::FunCall) -> ScalarNode {
+    match *fcall.function {
         Expr::RegexMatch(regex, _pos) => {
-            assert_eq!(arguments.len(), 1);
-            let single_arg = arguments.pop().unwrap();
+            assert_eq!(fcall.arguments.len(), 1);
+            let single_arg = fcall.arguments.pop().unwrap();
             RegexMatch::new_node(regex, single_arg)
         }
         Expr::RegexSubst(subst) => {
-            assert_eq!(arguments.len(), 1);
-            let single_arg = arguments.pop().unwrap();
+            assert_eq!(fcall.arguments.len(), 1);
+            let single_arg = fcall.arguments.pop().unwrap();
             RegexSubst::new_node(subst, single_arg)
         }
         _ => todo!(),

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -1,6 +1,6 @@
 use std::io::{self, StdinLock};
 
-use crate::{compile::{Expr, FunCall}, error::Error};
+use crate::{compile::{Builtin, Expr, FunCall}, error::Error};
 
 use super::{scalar::{self, ExecScalar, ScalarNode}, RtVal, StreamVar};
 
@@ -37,7 +37,12 @@ impl Iterator for StreamNode {
 // TODO turn into a From impl
 pub fn stream_from(expr: Expr) -> StreamNode {
     match expr {
-        Expr::Stdin => StdinState::new_node(),
+        Expr::Builtin(b, _pos) => {
+            match b {
+                Builtin::Stdin => StdinState::new_node(),
+                _ => panic!("Not a stream builtin: {:?}", b),
+            }
+        }
         Expr::Filter { filter_fn, data_source } => StreamFilter::new_node(filter_fn, data_source),
         Expr::Map { map_fn, data_source } => StreamMap::new_node(map_fn, data_source),
         // It's fine for us to panic here, as typechecking must have guaranteed that there

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -1,6 +1,6 @@
 use std::io::{self, StdinLock};
 
-use crate::{error::Error, compile::Expr};
+use crate::{compile::{Expr, FunCall}, error::Error};
 
 use super::{scalar::{self, ExecScalar, ScalarNode}, RtVal, StreamVar};
 
@@ -95,7 +95,7 @@ impl StreamFilter {
 
         // Compile the filter function as a function call
         let back_channel_read = Expr::ReadVar(back_channel_for_them);
-        let filter_fun_call = Expr::FunCall { function: filter_fn, arguments: vec![back_channel_read] };
+        let filter_fun_call = FunCall::new_expr_boxed(filter_fn, vec![back_channel_read]);
         let rt_filter_fn = scalar::scalar_from(filter_fun_call);
 
         let filter = StreamFilter {
@@ -168,7 +168,7 @@ impl StreamMap {
 
         // Compile the map function as a function call
         let back_channel_read = Expr::ReadVar(back_channel_for_them);
-        let map_fun_call = Expr::FunCall { function: map_fn, arguments: vec![back_channel_read] };
+        let map_fun_call = FunCall::new_expr_boxed(map_fn, vec![back_channel_read]);
         let rt_map_fn = scalar::scalar_from(map_fun_call);
 
         let map = StreamMap {

--- a/src/runtime/stream.rs
+++ b/src/runtime/stream.rs
@@ -40,11 +40,12 @@ pub fn stream_from(expr: Expr) -> StreamNode {
         Expr::Builtin(b, _pos) => {
             match b {
                 Builtin::Stdin => StdinState::new_node(),
+                Builtin::Filter { filter_fn, data_source } => StreamFilter::new_node(filter_fn, data_source),
+                Builtin::Map { map_fn, data_source } => StreamMap::new_node(map_fn, data_source),
                 _ => panic!("Not a stream builtin: {:?}", b),
             }
         }
-        Expr::Filter { filter_fn, data_source } => StreamFilter::new_node(filter_fn, data_source),
-        Expr::Map { map_fn, data_source } => StreamMap::new_node(map_fn, data_source),
+
         // It's fine for us to panic here, as typechecking must have guaranteed that there
         // are no surprises when we arrive here
         _ => panic!("Not a stream: {:?}", expr),

--- a/test/typecheck.001.sh
+++ b/test/typecheck.001.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+invalid_program 'm/abc/'
+#echo "Disabled test"


### PR DESCRIPTION
Add a new enum `Builtin` for the builtin functions and operators supported until now. These appear in expression trees as a new `Builtin` expression.